### PR TITLE
edit:ユーザー登録ページ

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,6 +23,7 @@
       <div class="actions flex justify-center">
         <%= f.submit (t "device.registrations.new.sign_in"), class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
       </div>
+    <% end %>
 
     <%= render "devise/shared/links" %>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,34 +1,27 @@
-<div class='flex flex-wrap justify-center mb-6'>
-  <div class=" col-md-10 col-lg-8 mx-auto">
-    <div class= "m-4 text-center text-3xl text-yellow-950">
+<div class='flex flex-wrap justify-center'>
+  <div class=" col-md-10 col-lg-8">
+    <div class= "mt-15 mb-10 font-bold text-center text-3xl text-yellow-900">
       ユーザー登録
     </div>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
        <%= render "devise/shared/error_messages", resource: resource %>
-      <div class="field">
-        <%= f.label :name %><br>
-        <%= f.text_field :name, class: "w-96 bg-stone-50 border border-stone-950 rounded-md",autofocus: true %>
+      <div class="field mb-6">
+        <%= f.text_field :name, class: "w-96 p-1.5 bg-stone-50 border border-stone-950 rounded-md", autofocus: true, placeholder:"ニックネーム" %>
       </div>
-      <div class="field">
-        <%= f.label :email %><br />
-        <%= f.email_field :email, class: "w-96 bg-stone-50 border border-stone-950 rounded-md", autocomplete: "email" %>
+      <div class="field mb-6">
+        <%= f.email_field :email, class: "w-96 p-1.5 bg-stone-50 border border-stone-950 rounded-md", placeholder:"メールアドレス" %>
       </div>
 
-      <div class="field">
-        <%= f.label :password %>
-        <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> 文字以上)</em>
-        <% end %><br />
-        <%= f.password_field :password, class: "w-96 bg-stone-50 border border-stone-950 rounded-md", autocomplete: "new-password" %>
+      <div class="field mb-6">
+        <%= f.password_field :password, class: "w-96 p-1.5 bg-stone-50 border border-stone-950 rounded-md", placeholder:"パスワード（ 6文字以上 ）" %>
       </div>
 
-      <div class="field">
-        <%= f.label :password_confirmation %><br />
-        <%= f.password_field :password_confirmation, class: "w-96 bg-stone-50 border border-stone-950 rounded-md", autocomplete: "new-password" %>
+      <div class="field mb-6">
+        <%= f.password_field :password_confirmation, class: "w-96 p-1.5 bg-stone-50 border border-stone-950 rounded-md", placeholder:"パスワード（確認）" %>
       </div>
 
       <div class="actions flex justify-center">
-        <%= f.submit (t "device.registrations.new.sign_in"), class: "mt-4 w-44 rounded-md bg-yellow-950 p-3 text-white focus:outline-none cursor-pointer" %>
+        <%= f.submit (t "device.registrations.new.sign_in"), class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
       </div>
     <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,7 +23,6 @@
       <div class="actions flex justify-center">
         <%= f.submit (t "device.registrations.new.sign_in"), class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
       </div>
-    <% end %>
 
     <%= render "devise/shared/links" %>
   </div>


### PR DESCRIPTION
画面遷移図に合わせてユーザー登録ページを編集。

・ボタンやテキストカラー変更
・ラベルではなくプレイスホルダーに入力項目を表示
・各フォームの配置調整