### PR TITLE
add:ポストに関連付けられた画像をスライダーに表示

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
 class StaticPagesController < ApplicationController
-  def top; end
+  def top
+    @posts = Post.order(created_at: :asc).limit(6)
+  end
 end

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -3,10 +3,11 @@
   <%= image_tag 'SweetsLogロゴのみ', width: 500 %>
 </div>
 <div class="slider">
-  <div><%= image_tag 'image1.png' %></div>
-  <div><%= image_tag 'image2.png' %></div>
-  <div><%= image_tag 'image3.png' %></div>
-  <div><%= image_tag 'image4.png' %></div>
+  <% @posts.each do |post| %>
+    <% if post.images.attached? %>
+      <div><%= image_tag(post.images.first.variant(resize_to_fill: [400, 400]), class:"rounded-xl") %></div>
+    <% end %>
+  <% end %>
 </div>
 <div class= "m-10 text-center text-xl text-yellow-900 font-semibold">
   <ul>


### PR DESCRIPTION
ホーム画面に表示しているスライダーで仮で表示させていた画像から、投稿されたポストに関連付けされている画像を取得し表示するように変更。
・投稿が増えた際にすべて取得すると処理が多くなるため、一番古い投稿から６件のみ取得するようにした