### PR TITLE
add:お気に入り機能

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,13 @@
+class LikesController < ApplicationController
+  def create
+    post = Post.find(params[:post_id])
+    current_user.like(post)
+    redirect_to posts_path, notice: "いいねしました"
+  end
+
+  def destroy
+    post = current_user.likes.find(params[:id]).post
+    current_user.unlike(post)
+    redirect_to posts_path, notice: "いいねを解除しました", status: :see_other
+  end
+end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,13 +1,11 @@
 class LikesController < ApplicationController
   def create
-    post = Post.find(params[:post_id])
-    current_user.like(post)
-    redirect_to posts_path, notice: "いいねしました"
+    @post = Post.find(params[:post_id])
+    current_user.like(@post)
   end
 
   def destroy
-    post = current_user.likes.find(params[:id]).post
-    current_user.unlike(post)
-    redirect_to posts_path, notice: "いいねを解除しました", status: :see_other
+    @post = current_user.likes.find(params[:id]).post
+    current_user.unlike(@post)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -42,6 +42,10 @@ class PostsController < ApplicationController
     redirect_to posts_path, notice: "ポストが削除されました"
   end
 
+  def likes
+    @like_posts = current_user.like_posts.includes(:user).order(created_at: :desc)
+  end
+
   private
 
   def post_params

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,6 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  validates :user_id, uniqueness: { scope: :post_id }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,4 +5,5 @@ class Post < ApplicationRecord
   has_many_attached :images
 
   belongs_to :user
+  has_many :likes, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,16 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_posts, through: :likes, source: :post
+
+  def like(post)
+    like_posts << post
+  end
+
+  def like(board)
+    like_posts.destroy(post)
+  end
+
+  def like?(post)
+    like_posts.include?(post)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,11 +9,15 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :like_posts, through: :likes, source: :post
 
+  def notown?(post)
+    !posts.include?(post)
+  end
+
   def like(post)
     like_posts << post
   end
 
-  def like(board)
+  def unlike(post)
     like_posts.destroy(post)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,6 @@ class User < ApplicationRecord
   validates :name, presence: true
 
   has_many :posts, dependent: :destroy
+  has_many :likes, dependent: :destroy
+  has_many :like_posts, through: :likes, source: :post
 end

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "like-button-for-post-#{@post.id}" do %>
+  <%= render "posts/unlike", post: @post %>
+<% end %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "unlike-button-for-post-#{@post.id}" do %>
+  <%= render "posts/like", post: @post %>
+<% end %>

--- a/app/views/posts/_like.html.erb
+++ b/app/views/posts/_like.html.erb
@@ -1,3 +1,3 @@
-<%= link_to likes_path(post_id: post.id), data: { turbo_method: :post } do %>
-  <span>❤︎</span>
+<%= link_to likes_path(post_id: post.id), id: "like-button-for-post-#{post.id}", data: { turbo_method: :post } do %>
+  <span style="font-size: 22px;">❤︎</span>
 <% end %>

--- a/app/views/posts/_like.html.erb
+++ b/app/views/posts/_like.html.erb
@@ -1,0 +1,3 @@
+<%= link_to likes_path(post_id: post.id), data: { turbo_method: :post } do %>
+  <span>❤︎</span>
+<% end %>

--- a/app/views/posts/_like_buttons.html.erb
+++ b/app/views/posts/_like_buttons.html.erb
@@ -1,0 +1,7 @@
+<div class= "ms-auto">
+  <% if current_user.like?(post) %>
+    <%= render "unlike", { post: post } %>
+  <% else %>
+    <%= render "like", { post: post } %>
+  <% end %>
+</div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <div class="w-96 h-96 bg-white border border-gray-200 shadow-2xs rounded-xl p-4 md:p-5 dark:bg-neutral-900 dark:border-neutral-700 dark:shadow-neutral-700/70">
   <a class="group relative block shrink-0 self-start overflow-hidden">
-    <div class="m-2 flex flex-wrap justify-center items-center transition duration-200 group-hover:scale-110">
+    <div class="m-2 flex flex-wrap justify-center transition duration-200 group-hover:scale-110">
       <% if post.images.attached? %>
         <%= image_tag(post.images.first.variant(resize_to_fill: [280, 280]), class:"rounded-xl") %>
       <% else %>
@@ -11,13 +11,14 @@
   <h3 class="text-lg text-center font-bold text-gray-800 dark:text-white">
     <%= link_to post.title, post_path(post) %>
   </h3>
-  <div class="flex">
-  <p class="mt-1 text-xs text-left font-medium text-gray-500 dark:text-neutral-500">
-    <i>投稿者：<%= post.user.name %></i>
-  </p>
-  <p class="mt-1 text-xs text-right">
-  <% if current_user.notown?(post) %>
-    <%= render 'like_buttons', { post: post } %>
-  <% end %>
+  <div class="flex items-center">
+    <p class="mt-1 text-xs text-left font-medium text-gray-500 dark:text-neutral-500">
+      <i>投稿者：<%= post.user.name %></i>
+    </p>
+    <% if current_user.notown?(post) %>
+      <p class="mt-1 text-xs text-right">
+        <%= render 'like_buttons', { post: post } %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -11,7 +11,13 @@
   <h3 class="text-lg text-center font-bold text-gray-800 dark:text-white">
     <%= link_to post.title, post_path(post) %>
   </h3>
+  <div class="flex">
   <p class="mt-1 text-xs text-left font-medium text-gray-500 dark:text-neutral-500">
     <i>投稿者：<%= post.user.name %></i>
   </p>
+  <p class="mt-1 text-xs text-right">
+  <% if current_user.notown?(post) %>
+    <%= render 'like_buttons', { post: post } %>
+  <% end %>
+  </div>
 </div>

--- a/app/views/posts/_unlike.html.erb
+++ b/app/views/posts/_unlike.html.erb
@@ -1,3 +1,3 @@
-<%= link_to like_path(current_user.likes.find_by(post_id: post.id)), data: { turbo_method: :delete } do %>
-  <span style="color:red;">❤︎</span>
+<%= link_to like_path(current_user.likes.find_by(post_id: post.id)), id: "unlike-button-for-post-#{post.id}", data: { turbo_method: :delete } do %>
+  <span style="color:red; font-size: 22px;">❤︎</span>
 <% end %>

--- a/app/views/posts/_unlike.html.erb
+++ b/app/views/posts/_unlike.html.erb
@@ -1,0 +1,3 @@
+<%= link_to like_path(current_user.likes.find_by(post_id: post.id)), data: { turbo_method: :delete } do %>
+  <span style="color:red;">❤︎</span>
+<% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,7 +3,7 @@
   投稿一覧ページ
 </div>
 <% if @posts.present? %>
-  <div class="pt-10 flex justify-center items-center min-h-screen">
+  <div class="pt-15 flex justify-center items-center min-h-screen">
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
       <%= render @posts %>
     </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,7 @@
 <%= render 'shared/flash_messages' %>
+<div class= "mt-15 font-bold text-center text-3xl text-yellow-900">
+  投稿一覧ページ
+</div>
 <% if @posts.present? %>
   <div class="pt-10 flex justify-center items-center min-h-screen">
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -1,0 +1,11 @@
+<%= render 'shared/flash_messages' %>
+<% if @like_posts.present? %>
+  <div class="pt-10 flex justify-center items-center min-h-screen">
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+      <%= render @like_posts %>
+    </div>
+  </div>
+<% else %>
+  <div class="mb-3 text-center">掲示板がありません</div>
+<% end %>
+</div>

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -9,6 +9,6 @@
     </div>
   </div>
 <% else %>
-  <div class="mb-3 text-center">掲示板がありません</div>
+  <div class="mt-10 text-center">掲示板がありません</div>
 <% end %>
 </div>

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -1,4 +1,7 @@
 <%= render 'shared/flash_messages' %>
+<div class= "mt-15 font-bold text-center text-3xl text-yellow-900">
+  <%= current_user.name %>のお気に入り投稿一覧
+</div>
 <% if @like_posts.present? %>
   <div class="pt-10 flex justify-center items-center min-h-screen">
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,11 +6,12 @@
       <% end %>
     </div>
     <ul class="flex mr-4">
-      <%= link_to 'HOME', root_path, class: "mr-4 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5" %>
-      <%= link_to 'POSTS', posts_path, class: "mr-4 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5" %>
-      <%= link_to 'NEWPOST', new_post_path, class: "mr-4 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5" %>
-      <%= link_to 'MY PAGE', user_path(current_user.id), class: "mr-4 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5" %>
-      <%= button_to 'LOGOUT', destroy_user_session_path, method: :delete, class: "mr-4 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5" %>
+      <%= link_to 'ホーム', root_path, class: "mr-4 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5" %>
+      <%= link_to '投稿一覧', posts_path, class: "mr-4 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5" %>
+      <%= link_to 'お気に入り', likes_posts_path, class: "mr-4 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5" %>
+      <%= link_to '新規作成', new_post_path, class: "mr-4 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5" %>
+      <%= link_to 'マイページ', user_path(current_user.id), class: "mr-4 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5" %>
+      <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, class: "mr-4 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5" %>
     </ul>
   </nav>
   <div class="flex items-center justify-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,12 @@ Rails.application.routes.draw do
   }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resources :users, only: [ :show ]
-  resources :posts, only: %i[ index new create show edit update destroy ]
+  resources :posts, only: %i[ index new create show edit update destroy ] do
+    collection do
+      get :likes
+    end
+  end
+  resources :likes, only: %i[create destroy]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20250606060955_create_likes.rb
+++ b/db/migrate/20250606060955_create_likes.rb
@@ -1,0 +1,7 @@
+class CreateLikes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :likes do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250606060955_create_likes.rb
+++ b/db/migrate/20250606060955_create_likes.rb
@@ -1,7 +1,11 @@
 class CreateLikes < ActiveRecord::Migration[7.2]
   def change
     create_table :likes do |t|
+      t.references :user, foreign_key: true
+      t.references :post, foreign_key: true
+
       t.timestamps
     end
+    add_index :likes, [:user_id, :post_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_28_061312) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_06_060955) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_28_061312) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false
     t.text "body", null: false
@@ -66,5 +76,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_28_061312) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
 end

--- a/test/fixtures/likes.yml
+++ b/test/fixtures/likes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LikeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
・postとuserの中間テーブル（Like）作成、紐づけ
・userモデルでlikeに関するアソシエーション定義
　　・like、unlike、like?
・ビュー作成（お気に入り一覧、お気に入り前・お気に入り後のボタン、ボタンの切り替え）
・ポスト投稿一覧の各ポスト右下にお気に入りマークを追加
・turboによる非同期通信化
