### PR TITLE
edit:複数投稿から単数投稿可能へ

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,9 +27,9 @@ class PostsController < ApplicationController
 
   def update
     @post = current_user.posts.find(params[:id])
-    if @post.update(post_params.except(:images))
-      if params[:post][:images].present?
-        @post.images.attach(params[:post][:images])
+    if @post.update(post_params.except(:image))
+      if params[:post][:image].present?
+        @post.image.attach(params[:post][:image])
       end
       redirect_to post_path(@post), notice: "ポストが更新されました"
     else
@@ -51,6 +51,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :body, images: [])
+    params.require(:post).permit(:title, :body, :image)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,7 +2,7 @@ class Post < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :body, presence: true, length: { maximum: 65_535 }
 
-  has_many_attached :images
+  has_one_attached :image
 
   belongs_to :user
   has_many :likes, dependent: :destroy

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,8 +2,8 @@
   <a class="group relative block shrink-0 self-start overflow-hidden">
     <div class="m-2 flex flex-wrap justify-center">
       <%= link_to post_path(post), class: "group" do %>
-        <% if post.images.attached? %>
-          <%= image_tag(post.images.first.variant(resize_to_fill: [200, 200]), class:"rounded-xl transition duration-200 group-hover:scale-105") %>
+        <% if post.image.attached? %>
+          <%= image_tag(post.image.variant(resize_to_fill: [200, 200]), class:"rounded-xl transition duration-200 group-hover:scale-105") %>
         <% else %>
           <%= image_tag 'no_image.png', class:"rounded-xl transition duration-300 group-hover:scale-105" %>
         <% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -5,34 +5,30 @@
       ポスト編集ページ
     </div>
     <div class= "flex-col">
-    <%= form_with model: @post do |f| %>
-      <%= render 'shared/object_error_messages', object: f.object %>
-      <div class="mb-3 flex flex-col">
-        <%= f.label :title %>
-        <%= f.text_field :title, class: "w-96 bg-stone-50 border border-stone-950 rounded-md" %>
-      </div>
-      <div class="mb-3 flex flex-col">
-        <%= f.label :body %>
-        <%= f.text_area :body, class: "w-96 bg-stone-50 border border-stone-950 rounded-md", rows: "10" %>
-      </div>
-      <div class="mb-3 flex flex-col">
-        <%= f.label :images %>
-        <%= f.file_field :images, multiple: true, class: "shadow appearance-none border-2 border-blue rounded w-full md:py-2 py-1 md:px-3 px-2 text-black leading-tight focus:outline-none focus:shadow-outline cursor-pointer" %>
-      </div>
-        <% if @post.images.attached? %>
-    <div class="mb-3">
-      <p>現在の画像:</p>
-      <% @post.images.each do |image| %>
-        <div class="text-center">
-          <%= image_tag image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail" %><br>
+      <%= form_with model: @post do |f| %>
+        <%= render 'shared/object_error_messages', object: f.object %>
+        <div class="mb-3 flex flex-col">
+          <%= f.label :title %>
+          <%= f.text_field :title, class: "w-96 bg-stone-50 border border-stone-950 rounded-md" %>
+        </div>
+        <div class="mb-3 flex flex-col">
+          <%= f.label :body %>
+          <%= f.text_area :body, class: "w-96 bg-stone-50 border border-stone-950 rounded-md", rows: "10" %>
+        </div>
+        <div class="mb-3 flex flex-col">
+          <%= f.label :image %>
+         <%= f.file_field :image, class: "shadow appearance-none border-2 border-blue rounded w-full md:py-2 py-1 md:px-3 px-2 text-black leading-tight focus:outline-none focus:shadow-outline cursor-pointer" %>
+        </div>
+        <% if @post.image.attached? %>
+          <div class="mb-3">
+            <p>現在の画像:</p>
+            <%= image_tag @post.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail" %><br>
+          </div>
+        <% end %>
+        <div class="actions flex justify-center">
+          <%= f.submit nil, class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
         </div>
       <% end %>
-    </div>
-  <% end %>
-      <div class="actions flex justify-center">
-        <%= f.submit nil, class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
-      </div>
-    <% end %>
     </div>
   </div>
 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -15,9 +15,8 @@
         <%= f.text_area :body, class: "w-96 bg-stone-50 border border-stone-950 rounded-md", rows: "10" %>
       </div>
       <div class="mb-3 flex flex-col">
-        <%= f.label :images %>
-        <%= f.file_field :images, multiple: true, class: "shadow appearance-none border-2 border-blue rounded w-full md:py-2 py-1 md:px-3 px-2 text-black leading-tight focus:outline-none focus:shadow-outline cursor-pointer" %>
-      </div>
+        <%= f.label :image %>
+        <%= f.file_field :image, class: "shadow appearance-none border-2 border-blue rounded w-full md:py-2 py-1 md:px-3 px-2 text-black leading-tight focus:outline-none focus:shadow-outline cursor-pointer" %>
       <div class="actions flex justify-center">
         <%= f.submit nil, class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
       </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,9 +2,9 @@
 <div class="container mx-auto px-6 md:px-10 py-8 my-8 md:bg-white rounded-xl min-h-screen max-w-screen-lg">
   <div class="flex flex-col items-center overflow-hidden md:flex-row">
     <a class="group relative block shrink-0 self-start overflow-hidden">
-      <% if @post.images.attached? %>
+      <% if @post.image.attached? %>
         <div class="flex flex-wrap justify-items-start items-center">
-          <%= image_tag(@post.images.first.variant(resize_to_fill: [350, 350]), class:"rounded-xl") %>
+          <%= image_tag(@post.image.variant(resize_to_fill: [350, 350]), class:"rounded-xl") %>
         </div>
       <% end %>
     </a>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -4,8 +4,8 @@
 </div>
 <div class="slider">
   <% @posts.each do |post| %>
-    <% if post.images.attached? %>
-      <div><%= image_tag(post.images.first.variant(resize_to_fill: [400, 400]), class:"rounded-xl") %></div>
+    <% if post.image.attached? %>
+      <div><%= image_tag(post.image.variant(resize_to_fill: [400, 400]), class:"rounded-xl") %></div>
     <% end %>
   <% end %>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -7,4 +7,4 @@ ja:
       post:
         title: タイトル
         body: 本文
-        images: 画像
+        image: 画像


### PR DESCRIPTION
複数投稿可能にする予定だったが、美味しかった料理を投稿するアプリケーションであり、一覧ページには料理の写真１枚を表示する予定のため、複数より単数のほうが目的に合っていると判断し、変更。