### PR TITLE
add:タグ付け機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
     if params[:tag_name]
       @pagy, @posts = pagy(Post.joins(:tags).where(tags: { name: params[:tag_name] }).order(created_at: :desc), limit: 12)
     else
-      @pagy, @posts = pagy(@q.result.includes(:user).order(created_at: :desc), limit: 12)
+      @pagy, @posts = pagy(@q.result(distinct: true).includes(:user).order(created_at: :desc), limit: 12)
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,11 @@
 class PostsController < ApplicationController
   def index
     @q = Post.ransack(params[:q])
-    @pagy, @posts = pagy(@q.result(distinct: true).includes(:user).order(created_at: :desc), limit: 12)
+    if params[:tag_name]
+      @pagy, @posts = pagy(Post.joins(:tags).where(tags: { name: params[:tag_name] }).order(created_at: :desc), limit: 12)
+    else
+      @pagy, @posts = pagy(@q.result.includes(:user).order(created_at: :desc), limit: 12)
+    end
   end
 
   def new
@@ -48,9 +52,14 @@ class PostsController < ApplicationController
     @pagy, @like_posts = pagy(@q.result(distinct: true).includes(:user).order(created_at: :desc), limit: 12)
   end
 
+  def tags
+    @tag = Tag.new
+  end
+
+
   private
 
   def post_params
-    params.require(:post).permit(:title, :body, :image)
+    params.require(:post).permit(:title, :body, :image, :tag_names)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,11 +11,11 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
 
   def self.ransackable_attributes(auth_object = nil)
-    %w[title body tag_names]
+    %w[title body]
   end
 
   def self.ransackable_associations(auth_object = nil)
-    []
+    %w[post_tags tags]
   end
 
   def tag_names

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,9 @@
 class Post < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :body, presence: true, length: { maximum: 65_535 }
+  has_many :post_tags, dependent: :destroy
+  has_many :tags, through: :post_tags
+
 
   has_one_attached :image
 
@@ -8,10 +11,20 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
 
   def self.ransackable_attributes(auth_object = nil)
-    %w[title body]
+    %w[title body tag_names]
   end
 
   def self.ransackable_associations(auth_object = nil)
     []
+  end
+
+  def tag_names
+    tags.map(&:name).join(",")
+  end
+
+  def tag_names=(names)
+    self.tags = names.split(",").map do |name|
+      Tag.find_or_create_by(name: name.strip)
+    end
   end
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,0 +1,6 @@
+class PostTag < ApplicationRecord
+  belongs_to :post
+  belongs_to :tag
+
+  validates :tag_id, uniqueness: { scope: :post_id }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,4 +4,12 @@ class Tag < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   scope :popular, -> { where(id: Post_tag.group(:tag_id).order('count_tag_id desc').limit(5).count(:tag_id).keys) }
+
+  def self.ransackable_attributes(auth_object = nil)
+    [ "name" ]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[post_tags posts]
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,7 +3,7 @@ class Tag < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
 
-  scope :popular, -> { where(id: Post_tag.group(:tag_id).order('count_tag_id desc').limit(5).count(:tag_id).keys) }
+  scope :popular, -> { where(id: Post_tag.group(:tag_id).order("count_tag_id desc").limit(5).count(:tag_id).keys) }
 
   def self.ransackable_attributes(auth_object = nil)
     [ "name" ]

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,8 @@
+class Tag < ApplicationRecord
+  has_many :post_tags, dependent: :destroy
+  has_many :posts, through: :post_tags
+
+  validates :name, presence: true, uniqueness: true
+
+  scope :popular, -> { where(id: Post_tag.group(:tag_id).order('count_tag_id desc').limit(5).count(:tag_id).keys) }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,5 @@
 class Tag < ApplicationRecord
   has_many :post_tags, dependent: :destroy
-  has_many :posts, through: :post_tags
 
   validates :name, presence: true, uniqueness: true
 

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,7 +1,7 @@
 <div class="m-4 flex flex-wrap gap-4 justify-center items-center">
 <%= search_form_for q, url: url do |f| %>
   <%= f.search_field :title_cont, placeholder: "料理名", class: "w-50 bg-stone-50 p-1 border border-stone-950 rounded-md" %>
-  <%= f.search_field :body_cont, placeholder: "キーワード", class: "w-96 bg-stone-50 p-1 border border-stone-950 rounded-md" %>
+  <%= f.search_field :body_or_tags_name_cont, placeholder: "キーワード", class: "w-96 bg-stone-50 p-1 border border-stone-950 rounded-md" %>
   <%= f.submit "検索", class: "mt-4 rounded-md bg-yellow-900 p-1 text-white focus:outline-none cursor-pointer" %>
 <% end %>
 </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -13,27 +13,26 @@
           <p class= "text-yellow-950">現在の画像:</p>
           <%= image_tag (@post.image.variant(resize_to_fill: [350, 350])) %>
         <% end %>
-        <div class="mt-5">
+        <div class="mt-6">
           <%= f.label :image, class: "text-yellow-950" %>
           <%= f.file_field :image, class: "shadow appearance-none border-2 border-yellow-950 rounded w-full py-1 px-2 text-yellow-950 leading-tight focus:outline-none focus:shadow-outline cursor-pointer" %>
         </div>
       </div>
       <div class="ml-8 mr-8 col-span-1 justify-self-start">
-        <div class= "mb-6 flex flex-col">
+        <div class= "mb-3 flex flex-col">
           <%= f.label :title, class: "text-yellow-950" %>
-          <%= f.text_field :title, class: "w-96 bg-stone-50 border border-yellow-950 rounded-md" %>
+          <%= f.text_field :title, class: "w-96 py-1 bg-stone-50 border border-yellow-950 rounded-md" %>
         </div>
         <div class="mb-3 flex flex-col">
           <%= f.label :body, class: "text-yellow-950" %>
-          <%= f.text_area :body, class: "w-96 bg-stone-50 border border-yellow-950 rounded-md", rows: "15" %>
+          <%= f.text_area :body, class: "w-96 bg-stone-50 border border-yellow-950 rounded-md", rows: "12" %>
+        </div>
+        <div class="mb-3 flex flex-col">
+          <%= f.label :tag_names, class: "text-yellow-950" %>
+          <%= f.text_field :tag_names, value: f.object.tag_names, class: 'w-96 py-1 bg-stone-50 border border-yellow-950 rounded-md', placeholder: '  ,で区切って入力してください' %>
         </div>
       </div>
     </div>
-    <div class="mb-3 flex justify-center">
-      <div class="mb-3 flex flex-col">
-        <%= f.label :tag_names %>
-        <%= f.text_field :tag_names, value: f.object.tag_names, class: 'w-96 bg-stone-50 border border-stone-950 rounded-md', placeholder: '  ,で区切って入力してください' %>
-      </div>
     </div>
     <div class="actions flex justify-center">
       <%= f.submit nil, class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -29,6 +29,12 @@
         </div>
       </div>
     </div>
+    <div class="mb-3 flex justify-center">
+      <div class="mb-3 flex flex-col">
+        <%= f.label :tag_names %>
+        <%= f.text_field :tag_names, value: f.object.tag_names, class: 'w-96 bg-stone-50 border border-stone-950 rounded-md', placeholder: '  ,で区切って入力してください' %>
+      </div>
+    </div>
     <div class="actions flex justify-center">
       <%= f.submit nil, class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
     </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -26,6 +26,12 @@
         </div>
       </div>
     </div>
+    <div class="mb-3 flex justify-center">
+      <div class="mb-3 flex flex-col">
+        <%= f.label :tag_names %>
+        <%= f.text_field :tag_names, value: f.object.tag_names, class: 'w-96 bg-stone-50 border border-stone-950 rounded-md', placeholder: '  ,で区切って入力してください' %>
+      </div>
+    </div>
     <div class="actions flex justify-center">
        <%= f.submit nil, class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
     </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -10,27 +10,26 @@
       <div>
         <p class= "text-yellow-950 text-center">↓　ここに画像が入ります　↓</p>
         <%= image_tag "no_image.png", width: 350, height: 350, class:"rounded-xl transition duration-300 group-hover:scale-105" %>
-        <div class="mt-5">
+        <div class="mt-6">
           <%= f.label :image, class: "text-yellow-950" %>
           <%= f.file_field :image, class: "shadow appearance-none border-2 border-yellow-950 rounded w-full py-1 px-2 text-yellow-950 leading-tight focus:outline-none focus:shadow-outline cursor-pointer" %>
         </div>
       </div>
       <div class="ml-8 mr-8 col-span-1 justify-self-start">
         <div class="mb-3 flex flex-col">
-          <%= f.label :title %>
-          <%= f.text_field :title, class: "w-96 bg-stone-50 border border-stone-950 rounded-md" %>
+          <%= f.label :title, class: "text-yellow-950" %>
+          <%= f.text_field :title, class: "w-96 py-1 bg-stone-50 border border-yellow-950 rounded-md" %>
         </div>
         <div class="mb-3 flex flex-col">
-          <%= f.label :body %>
-          <%= f.text_area :body, class: "w-96 bg-stone-50 border border-stone-950 rounded-md", rows: "15" %>
+          <%= f.label :body, class: "text-yellow-950" %>
+          <%= f.text_area :body, class: "w-96 bg-stone-50 border border-yellow-950 rounded-md", rows: "12" %>
+        </div>
+        <div class="mb-3 flex flex-col">
+          <%= f.label :tag_names, class: "text-yellow-950" %>
+          <%= f.text_field :tag_names, value: f.object.tag_names, class: 'w-96 py-1 bg-stone-50 border border-yellow-950 rounded-md', placeholder: '  ,で区切って入力してください' %>
         </div>
       </div>
     </div>
-    <div class="mb-3 flex justify-center">
-      <div class="mb-3 flex flex-col">
-        <%= f.label :tag_names %>
-        <%= f.text_field :tag_names, value: f.object.tag_names, class: 'w-96 bg-stone-50 border border-stone-950 rounded-md', placeholder: '  ,で区切って入力してください' %>
-      </div>
     </div>
     <div class="actions flex justify-center">
        <%= f.submit nil, class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -14,6 +14,13 @@
       <div class= "mt-10 text-yellow-950">
         <%= @post.body %>
       </div>
+      <div class="mt-6 flex-col">
+        <% @post.tags.each do |tag| %>
+          <div class="text-yellow-900">
+            #<%= link_to tag.name, posts_path(tag_name: tag.name) %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
   <% if @post.user == current_user %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -8,3 +8,4 @@ ja:
         title: タイトル
         body: 本文
         image: 画像
+        tag_names: タグ

--- a/db/migrate/20250612060308_create_tags.rb
+++ b/db/migrate/20250612060308_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250612060459_create_post_tags.rb
+++ b/db/migrate/20250612060459_create_post_tags.rb
@@ -1,0 +1,10 @@
+class CreatePostTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,7 +84,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_12_060459) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name", null: false
+    t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_06_060955) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_12_060459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_06_060955) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
+  create_table "post_tags", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false
     t.text "body", null: false
@@ -59,6 +68,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_06_060955) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -69,7 +84,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_06_060955) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name"
+    t.string "name", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -78,5 +93,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_06_060955) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "post_tags", "posts"
+  add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"
 end

--- a/test/fixtures/post_tags.yml
+++ b/test/fixtures/post_tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  post: one
+  tag: one
+
+two:
+  post: two
+  tag: two

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/post_tag_test.rb
+++ b/test/models/post_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
・tag , post_tag(中間）テーブル作成
・新規作成フォーム、編集フォームにてタグ付け可能
・タグ付けする際は　”,”　で区切る
・キーワード検索フォームでPostのbodyに対してのみ検索可能にしていたが、tagのnameを追加
・ポスト詳細ページにてタグをクリックすることでもそのタグが付いたポストの一覧ページへ遷移可能