### PR TITLE
add:カレンダー

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem "ransack"
 
 gem "pagy"
 
+gem "simple_calendar"
+
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,6 +299,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simple_calendar (3.1.0)
+      rails (>= 6.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -366,6 +368,7 @@ DEPENDENCIES
   ransack
   rubocop-rails-omakase
   selenium-webdriver
+  simple_calendar
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -47,3 +47,73 @@
   border-style: none;
   background-color: #f3f4f6;
 }
+
+.simple-calendar {
+  table {
+    -webkit-border-horizontal-spacing: px;
+    -webkit-border-vertical-spacing: 0px;
+    background-color: rgba(255, 255, 255, 0);
+    border: 1px solid var(--color-yellow-950);
+    border-collapse: collapse;
+    box-sizing: border-box;
+  }
+
+  tr {
+    border-collapse: collapse;
+  }
+
+  th {
+    width: 50px;
+    padding: 5px;
+    border-bottom: 2px solid var(--color-yellow-950);
+    border-collapse: collapse;
+    border-left: 1px solid var(--color-yellow-950);
+    border-right: 1px solid var(--color-yellow-950);
+    box-sizing: border-box;
+    text-align: center;
+    background: #ffffff;
+    color: var(--color-yellow-900);
+  }
+
+  td {
+    padding: 5px;
+    vertical-align: top;
+
+
+    border: 1px solid #ffffff;
+    border-top-color: var(--color-yellow-950);
+    border-top-style: solid;
+    border-top-width: 1px;
+    border-right-color: var(--color-yellow-950);
+    border-right-style: solid;
+    border-right-width: 1px;
+    border-bottom-color: var(--color-yellow-950);
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    border-left-color: var(--color-yellow-950);
+    border-left-style: solid;
+    border-left-width: 1px;
+  }
+
+  .day {
+    height: 50px;
+    background: #ffffff;
+  }
+
+  .today {
+    background: #ffffc0;
+  }
+
+  .prev-month {
+    background: #e7e7e7;
+  }
+
+  .next-month {
+    background: #e7e7e7;
+
+  }
+}
+
+.fs10 {
+  font-size: 10px;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,5 +7,13 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @q = @user.posts.ransack(params[:q])
     @pagy, @posts = pagy(@q.result(distinct: true).order(created_at: :desc), limit: 12)
+
+    if params[:date].present?
+      date = Date.parse(params[:date]) rescue nil
+      if date
+        @posts = @user.posts.where(created_at: date.beginning_of_day..date.end_of_day).order(created_at: :asc)
+      end
+    end
+    @pagy, @calendar_posts = pagy(@q.result(distinct: true).order(created_at: :desc), limit: 12)
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -17,19 +17,25 @@ document.addEventListener("turbo:load", function() {
   });
 });
 
-document.addEventListener("turbo:load", () => {
-  const toggleBtn = document.getElementById("toggle-calendar");
-  const calendar = document.getElementById("calendar-container");
+document.addEventListener('turbo:load', () => {
+  const toggleBtn = document.getElementById('toggle-calendar');
+  const calendar = document.getElementById('calendar-container');
 
-  if (toggleBtn && calendar) {
-    toggleBtn.addEventListener("click", () => {
-      if (calendar.style.display === "none" || calendar.style.display === "") {
-        calendar.style.display = "block";
-        toggleBtn.textContent = "カレンダーを非表示";
-      } else {
-        calendar.style.display = "none";
-        toggleBtn.textContent = "カレンダーを表示";
-      }
-    });
-  }
+  if (!toggleBtn || !calendar) return;
+
+  const isOpen = localStorage.getItem('calendarOpen') === 'true';
+  calendar.style.display = isOpen ? 'block' : 'none';
+  toggleBtn.textContent = isOpen ? 'カレンダーを非表示' : 'カレンダーを表示';
+
+  toggleBtn.onclick = () => {
+    if (calendar.style.display === 'none') {
+      calendar.style.display = 'block';
+      toggleBtn.textContent = 'カレンダーを非表示';
+      localStorage.setItem('calendarOpen', 'true');
+    } else {
+      calendar.style.display = 'none';
+      toggleBtn.textContent = 'カレンダーを表示';
+      localStorage.setItem('calendarOpen', 'false');
+    }
+  };
 });

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -16,3 +16,20 @@ document.addEventListener("turbo:load", function() {
     infinite: true
   });
 });
+
+document.addEventListener("turbo:load", () => {
+  const toggleBtn = document.getElementById("toggle-calendar");
+  const calendar = document.getElementById("calendar-container");
+
+  if (toggleBtn && calendar) {
+    toggleBtn.addEventListener("click", () => {
+      if (calendar.style.display === "none" || calendar.style.display === "") {
+        calendar.style.display = "block";
+        toggleBtn.textContent = "カレンダーを非表示";
+      } else {
+        calendar.style.display = "none";
+        toggleBtn.textContent = "カレンダーを表示";
+      }
+    });
+  }
+});

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,29 @@
+<div class="simple-calendar">
+  <div class="mb-1 calendar-heading text-yellow-950">
+    <%= link_to t('simple_calendar.previous', default: "<"), calendar.url_for_previous_view, class:"mr-1 font-bold text-yellow-950 hover:text-yellow-600" %>
+      <time datetime="<%= start_date.strftime("%Y-%m") %>" class="calendar-title"><%= start_date.year %>年<%= t("date.month_names")[start_date.month] %></time>
+    <%= link_to t('simple_calendar.next', default: ">"), calendar.url_for_next_view, class:"mr-1 font-bold text-yellow-950 hover:text-yellow-600" %>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/users/_calendar.html.erb
+++ b/app/views/users/_calendar.html.erb
@@ -1,0 +1,15 @@
+<div id="calendar-container" style="display: none;">
+  <div class='flex justify-center mb-6'>
+    <%= month_calendar(events: @calendar_posts, attribute: :created_at, class: "w-full table-fixed text-yellow-900 text-sm") do |date, posts| %>
+      <div class="text-sm text-yellow-950 text-center">
+        <%= date.day %>
+      </div>
+      <% posts_for_date = posts.select { |post| post.created_at.to_date == date } %>
+      <% if posts_for_date.any? %>
+        <div class="text-sm text-center">
+          <%= link_to "#{posts_for_date.count}件", my_posts_user_path(current_user, date: date),class:"font-bold text-yellow-900 hover:text-yellow-600" %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/my_posts.html.erb
+++ b/app/views/users/my_posts.html.erb
@@ -4,8 +4,8 @@
 <div class='flex justify-center mb-6'>
 <%= month_calendar(events: @calendar_posts, attribute: :created_at, class: "w-full table-fixed border border-gray-800 text-sm") do |date, posts| %>
   <div class="w-15 h-15 p-1 bg-white border border-yellow-800">
-    <div class="flex flex-col space-y-1">
-      <div class="text-sm text-yellow-900 text-center"><%= date.day %></div>
+    <div class="flex flex-col">
+      <div class="m-1 text-sm text-yellow-900 text-center"><%= date.day %></div>
       <% posts_for_date = posts.select { |post| post.created_at.to_date == date } %>
         <% if posts_for_date.any? %>
           <div class="text-sm text-center">

--- a/app/views/users/my_posts.html.erb
+++ b/app/views/users/my_posts.html.erb
@@ -1,6 +1,21 @@
 <div class= "mt-15 mb-10 font-bold text-center text-3xl text-yellow-900">
   <%= @user.name %>の投稿
 </div>
+<div class='flex justify-center mb-6'>
+<%= month_calendar(events: @calendar_posts, attribute: :created_at, class: "w-full table-fixed border border-gray-800 text-sm") do |date, posts| %>
+  <div class="w-15 h-15 p-1 bg-white border border-yellow-800">
+    <div class="flex flex-col space-y-1">
+      <div class="text-sm text-yellow-900 text-center"><%= date.day %></div>
+      <% posts_for_date = posts.select { |post| post.created_at.to_date == date } %>
+        <% if posts_for_date.any? %>
+          <div class="text-sm text-center">
+            <%= link_to "#{posts_for_date.count}件", my_posts_user_path(current_user, date: date),class:"font-bold text-yellow-900 hover:text-yellow-600" %>
+          </div>
+        <% end %>
+    </div>
+  </div>
+<% end %>
+</div>
 <%= render "posts/search_form", q: @q, url: my_posts_user_path(current_user) %>
 <% if @posts.present? %>
   <div class="mt-15 max-w-screen-xl mx-auto">
@@ -14,16 +29,3 @@
 <% else %>
   <div class="mb-3 text-center">掲示板がありません</div>
 <% end %>
-<div class='flex justify-center mb-6'>
-<%= month_calendar(events: @calendar_posts, attribute: :created_at, class: "w-full table-fixed border border-gray-800 text-sm") do |date, posts| %>
-  <div class="w-30 h-24 p-1 border border-yellow-800">
-    <div class="flex flex-col space-y-1">
-      <div class="text-sm text-center"><%= date.day %></div>
-      <% posts_for_date = posts.select { |post| post.created_at.to_date == date } %>
-       <% if posts_for_date.any? %>
-        <%= link_to "#{posts_for_date.count}件", my_posts_user_path(current_user, date: date) %>
-      <% end %>
-    </div>
-  </div>
-<% end %>
-</div>

--- a/app/views/users/my_posts.html.erb
+++ b/app/views/users/my_posts.html.erb
@@ -14,3 +14,16 @@
 <% else %>
   <div class="mb-3 text-center">掲示板がありません</div>
 <% end %>
+<div class='flex justify-center mb-6'>
+<%= month_calendar(events: @calendar_posts, attribute: :created_at, class: "w-full table-fixed border border-gray-800 text-sm") do |date, posts| %>
+  <div class="w-30 h-24 p-1 border border-yellow-800">
+    <div class="flex flex-col space-y-1">
+      <div class="text-sm text-center"><%= date.day %></div>
+      <% posts_for_date = posts.select { |post| post.created_at.to_date == date } %>
+       <% if posts_for_date.any? %>
+        <%= link_to "#{posts_for_date.count}件", my_posts_user_path(current_user, date: date) %>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+</div>

--- a/app/views/users/my_posts.html.erb
+++ b/app/views/users/my_posts.html.erb
@@ -9,21 +9,7 @@
     カレンダーを表示
   </button>
 </div>
-<div id="calendar-container" style="display: none;">
-  <div class='flex justify-center mb-6'>
-    <%= month_calendar(events: @calendar_posts, attribute: :created_at, class: "w-full table-fixed text-yellow-900 text-sm") do |date, posts| %>
-      <div class="text-sm text-yellow-950 text-center">
-        <%= date.day %>
-      </div>
-      <% posts_for_date = posts.select { |post| post.created_at.to_date == date } %>
-      <% if posts_for_date.any? %>
-        <div class="text-sm text-center">
-          <%= link_to "#{posts_for_date.count}件", my_posts_user_path(current_user, date: date),class:"font-bold text-yellow-900 hover:text-yellow-600" %>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
-</div>
+<%= render "calendar", calendar_posts: @calendar_posts %>
 
 <% if @posts.present? %>
   <div class="mt-15 max-w-screen-xl mx-auto">

--- a/app/views/users/my_posts.html.erb
+++ b/app/views/users/my_posts.html.erb
@@ -2,10 +2,10 @@
   <%= @user.name %>の投稿
 </div>
 <div class='flex justify-center mb-6'>
-<%= month_calendar(events: @calendar_posts, attribute: :created_at, class: "w-full table-fixed border border-gray-800 text-sm") do |date, posts| %>
-  <div class="w-15 h-15 p-1 bg-white border border-yellow-800">
-    <div class="flex flex-col">
-      <div class="m-1 text-sm text-yellow-900 text-center"><%= date.day %></div>
+<%= month_calendar(events: @calendar_posts, attribute: :created_at, class: "w-full table-fixed text-yellow-900 text-sm") do |date, posts| %>
+  <div class="text-sm text-yellow-950 text-center">
+    <%= date.day %>
+  </div>
       <% posts_for_date = posts.select { |post| post.created_at.to_date == date } %>
         <% if posts_for_date.any? %>
           <div class="text-sm text-center">

--- a/app/views/users/my_posts.html.erb
+++ b/app/views/users/my_posts.html.erb
@@ -1,22 +1,30 @@
 <div class= "mt-15 mb-10 font-bold text-center text-3xl text-yellow-900">
   <%= @user.name %>の投稿
 </div>
-<div class='flex justify-center mb-6'>
-<%= month_calendar(events: @calendar_posts, attribute: :created_at, class: "w-full table-fixed text-yellow-900 text-sm") do |date, posts| %>
-  <div class="text-sm text-yellow-950 text-center">
-    <%= date.day %>
-  </div>
-      <% posts_for_date = posts.select { |post| post.created_at.to_date == date } %>
-        <% if posts_for_date.any? %>
-          <div class="text-sm text-center">
-            <%= link_to "#{posts_for_date.count}件", my_posts_user_path(current_user, date: date),class:"font-bold text-yellow-900 hover:text-yellow-600" %>
-          </div>
-        <% end %>
-    </div>
-  </div>
-<% end %>
-</div>
+
 <%= render "posts/search_form", q: @q, url: my_posts_user_path(current_user) %>
+
+<div class="flex justify-center">
+  <button id="toggle-calendar" class="text-yellow-900 hover:text-yellow-600">
+    カレンダーを表示
+  </button>
+</div>
+<div id="calendar-container" style="display: none;">
+  <div class='flex justify-center mb-6'>
+    <%= month_calendar(events: @calendar_posts, attribute: :created_at, class: "w-full table-fixed text-yellow-900 text-sm") do |date, posts| %>
+      <div class="text-sm text-yellow-950 text-center">
+        <%= date.day %>
+      </div>
+      <% posts_for_date = posts.select { |post| post.created_at.to_date == date } %>
+      <% if posts_for_date.any? %>
+        <div class="text-sm text-center">
+          <%= link_to "#{posts_for_date.count}件", my_posts_user_path(current_user, date: date),class:"font-bold text-yellow-900 hover:text-yellow-600" %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
 <% if @posts.present? %>
   <div class="mt-15 max-w-screen-xl mx-auto">
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-7 justify-items-center">

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,6 @@ module Myapp
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
     config.time_zone = "Tokyo"
+    config.beginning_of_week = :sunday
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,3 +2,7 @@ ja:
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
+  simple_calendar:
+    previous: "先月"
+    next: "来月"
+    today: "今月"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,7 +2,3 @@ ja:
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
-  simple_calendar:
-    previous: "先月"
-    next: "来月"
-    today: "今月"


### PR DESCRIPTION
simple calendarを使い、my_postページにカレンダーを表示。
・その日に何件投稿されたかを表示している
・件数をクリックすと、その日投稿したポストのみが一覧として表示される
・常にカレンダーが表示されているとポスト一覧が見にくいと感じたため、カレンダー表示/非表示切り替えボタン追加
　（デフォルトは非表示）