### PR TITLE
fix:error_messageコード、add:必須入力マーク追加

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,5 @@
 <div class="container mx-auto px-6 py-15 my-15 bg-white rounded-xl min-h-screen max-w-screen-lg">
+  <%= render "shared/object_error_messages", object: @post %>
   <%= form_with model: @post do |f| %>
     <div class="grid grid-cols-2 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2 justify-items-center">
       <div>
@@ -13,25 +14,42 @@
       </div>
       <div class="ml-8 mr-8 col-span-1 justify-self-start">
         <div class= "mb-3 flex flex-col">
-          <%= f.label :title, class: "text-yellow-950" %>
+          <div class= "flex">
+            <%= f.label :title, class: "text-yellow-950" %>
+            <span class="text-red-600">*</span>
+          </div>
           <%= f.text_field :title, class: "w-96 py-1 bg-stone-50 border border-yellow-950 rounded-md" %>
         </div>
+
         <div class="mb-3 flex flex-col">
-          <%= f.label :body, class: "text-yellow-950" %>
+          <div class= "flex">
+            <%= f.label :body, class: "text-yellow-950" %>
+            <span class="text-red-600">*</span>
+          </div>
           <%= f.text_area :body, class: "w-96 bg-stone-50 border border-yellow-950 rounded-md", rows: "12" %>
         </div>
+
         <div class="mb-3 flex flex-col">
           <%= f.label :tag_names, class: "text-yellow-950" %>
           <%= f.text_field :tag_names, value: f.object.tag_names, class: "w-96 py-1 bg-stone-50 border border-yellow-950 rounded-md", placeholder: " 複数登録する場合はカンマ( , )で区切ってください" %>
         </div>
+
         <div class="mb-3 flex flex-col">
-          <%= f.label :spot %>
+          <div class= "flex">
+            <%= f.label :spot %>
+            <span class="text-red-600">*</span>
+          </div>
           <%= f.text_field :spot, id: "spot", class: "w-96 py-1 bg-stone-50 border border-yellow-950 rounded-md", placeholder: " 店名や市町村名を入力すると候補が出てきます" %>
         </div>
+
         <div class="mb-3 flex flex-col">
-          <%= f.label :address %>
+          <div class= "flex">
+            <%= f.label :address %>
+            <span class="text-red-600">*</span>
+          </div>
           <%= f.text_field :address, id: "address", class: "w-96 py-1 bg-stone-50 border border-yellow-950 rounded-md", placeholder: " 候補を選択することで住所が自動で入力されます" %>
         </div>
+
         <%= f.hidden_field :latitude, id: "latitude" %>
         <%= f.hidden_field :longitude, id: "longitude" %>
       </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -3,6 +3,4 @@
   ポスト編集ページ
 </div>
 
-<%= render 'shared/flash_messages' %>
-
 <%= render "form", { post: @post } %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -5,7 +5,7 @@ ja:
       email: 'メールアドレス'
     attributes:
       post:
-        title: タイトル
+        title: メニュー名
         body: 本文
         image: 画像
         tag_names: タグ


### PR DESCRIPTION
postのフォームページにて、バリデーションによるエラーメッセージを表示させるコードに誤りがあったため修正。
追加で、投稿の際に必須入力のフォームがどれか分かりやすくするため、赤い*マークを付けた。