### PR TITLE
add:プロフィールページ

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,12 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+  before_action :configure_permitted_parameters, if: :devise_controller?
   include Pagy::Backend
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :image])
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,6 +24,7 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
+    @user = @post.user
   end
 
   def edit

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   def index
     @q = Post.ransack(params[:q])
     if params[:tag_name]
-      @pagy, @posts = pagy(Post.joins(:tags).where(tags: { name: params[:tag_name] }).order(created_at: :desc), limit: 12)
+      @pagy, @posts = pagy(Post.joins(:tags).where(tags: { name: params[:tag_name] }).includes(:user).order(created_at: :desc), limit: 12)
     else
       @pagy, @posts = pagy(@q.result(distinct: true).includes(:user).order(created_at: :desc), limit: 12)
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -59,4 +59,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def after_inactive_sign_up_path_for(resource)
     root_path
   end
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+
+  def after_update_path_for(resource)
+    profile_user_path(current_user.id)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,4 +22,8 @@ class UsersController < ApplicationController
     @pagy, @posts = pagy(scoped_posts.order(created_at: :desc), items: 12)
     @calendar_posts = @q.result(distinct: true)
   end
+
+  def profile
+    @user = current_user
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
 
   def profile
     @user = User.find(params[:id])
-    @pagy, @posts = pagy(@user.posts.order(created_at: :desc), items: 12)
+    @pagy, @posts = pagy(@user.posts.includes(:user).order(created_at: :desc), items: 12)
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,26 @@ class UsersController < ApplicationController
   end
 
   def profile
+    @user = User.find(params[:id])
+    @pagy, @posts = pagy(@user.posts.order(created_at: :desc), items: 12)
+  end
+
+  def edit
     @user = current_user
+  end
+
+  def update
+    @user = current_user
+    if @user.update(user_params)
+      redirect_to profile_user_path, notice: 'プロフィールを更新しました。'
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :image)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   validates :name, presence: true
 
+  has_one_attached :image
+
   has_many :posts, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_posts, through: :likes, source: :post

--- a/app/views/posts/_edit_and_destroy_buttons.html.erb
+++ b/app/views/posts/_edit_and_destroy_buttons.html.erb
@@ -1,0 +1,10 @@
+<%= link_to edit_post_path(post), class: "focus:outline-none cursor-pointer" do %>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5.5 text-yellow-950">
+    <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+  </svg>
+<% end %>
+<%= link_to post_path(post), class: "focus:outline-none cursor-pointer", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5.5 text-yellow-950">
+    <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+  </svg>
+<% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -61,7 +61,7 @@
       </div>
     </div>
     <div class="actions flex justify-center">
-      <%= f.submit nil, class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
+      <%= f.submit "投稿", class: "mt-4 w-40 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
     </div>
 <% end %>
 </div>

--- a/app/views/posts/_like_buttons.html.erb
+++ b/app/views/posts/_like_buttons.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.like?(post) %>
-   <%= render "unlike", { post: post } %>
+   <%= render "posts/unlike", { post: post } %>
 <% else %>
-  <%= render "like", { post: post } %>
+  <%= render "posts/like", { post: post } %>
 <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -10,17 +10,19 @@
       <% end %>
     </div>
   </div>
-  <h3 class="text-base text-center font-bold text-yellow-900">
+  <div class="text-base text-center font-bold text-yellow-900 truncate max-w-[95%]">
     <%= link_to post.title, post_path(post), class: "hover:text-yellow-600" %>
-  </h3>
+  </div>
   <div class="flex items-end justify-between mt-auto">
-    <div class="mr-12 text-xs text-yellow-600">
-      <i><%= l post.created_at %></i>
+    <div class="flex justify-self-start">
+      <%= render "user_profile_button", { user: post.user } %>
     </div>
     <% if current_user.notown?(post) %>
       <%= render 'like_buttons', { post: post } %>
     <% else %>
+    <div class="flex gap-1">
       <%= render "edit_and_destroy_buttons", { post: post } %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -20,17 +20,7 @@
     <% if current_user.notown?(post) %>
       <%= render 'like_buttons', { post: post } %>
     <% else %>
-      <%= link_to edit_post_path(post), class: "focus:outline-none cursor-pointer" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5.5 text-yellow-950">
-          <path stroke-linecap="round" stroke-linejoin="round"
-          d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
-        </svg>
-      <% end %>
-      <%= link_to post_path(post), class: "focus:outline-none cursor-pointer", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5.5 text-yellow-950">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-        </svg>
-      <% end %>
+      <%= render "edit_and_destroy_buttons", { post: post } %>
     <% end %>
   </div>
 </div>

--- a/app/views/posts/_user_profile_button.html.erb
+++ b/app/views/posts/_user_profile_button.html.erb
@@ -1,0 +1,8 @@
+<% if user.image.attached? %>
+    <%= image_tag url_for(user.image.variant(resize_to_fill: [20, 20])), class: "rounded-full transition duration-200 group-hover:scale-105" %>
+<% else %>
+  <%= image_tag "プロフィールマーク.png", class:"rounded-full", width: 25%>
+<% end %>
+<div class="mx-2 my-auto">
+  <%= link_to user.name, profile_user_path(user), class: "text-xs font-bold text-yellow-900 hover:text-yellow-700" %>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/flash_messages" %>
-<div class="container mx-auto px-6 py-15 my-15 bg-white shadow-sm shadow-2xs rounded-xl min-h-screen max-w-screen-lg text-sm">
+<div class="container mx-auto px-5 py-15 my-15 bg-white shadow-sm shadow-2xs rounded-xl min-h-screen max-w-screen-lg text-sm">
   <div class="grid grid-cols-2 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2 justify-items-center">
     <div class="mb-10">
       <% if @post.image.attached? %>
@@ -9,19 +9,25 @@
       <% end %>
     </div>
 
-    <div class="pr-15 col-span-1 justify-self-start">
+    <div class="justify-self-start col-span-1">
+      <div class="flex justify-between items-center w-110">
+        <div class="text-2xl font-bold text-gray-800">
+          <%= @post.title %>
+        </div>
+        <% if current_user.notown?(@post) %>
+          <div>
+          <%= render "like_buttons", { post: @post } %>
+          </div>
+        <% else %>
+          <div class="flex gap-2">
+            <%= render "edit_and_destroy_buttons", { post: @post } %>
+          </div>
+        <% end %>
+      </div>
       <div class="text-gray-400">
         <%= l @post.created_at %>
       </div>
-      <div class="flex justify-between mt-auto">
-        <h2 class="text-2xl font-bold text-gray-800">
-          <%= @post.title %>
-        </h2>
-        <% if current_user.notown?(@post) %>
-          <div><%= render 'like_buttons', { post: @post } %></div>
-        <% end %>
-      </div>
-      <div class= "mt-10 text-yellow-950">
+      <div class= "mt-10 text-yellow-950 max-w-[90%]">
         <%= @post.body %>
       </div>
       <div class="mt-6 flex-col">
@@ -45,17 +51,19 @@
     </div>
 
     <div class="col-span-2">
-      <div id="map" style="width: 830px; height: 400px;" class="mt-6 mb-6 rounded-xl"></div>
+      <div id="map" style="width: 850px; height: 400px;" class="mt-6 mb-6 rounded-xl"></div>
     </div>
   </div>
 
-  <% if @post.user == current_user %>
-    <div class="flex justify-center items-center">
-      <div class= "m-10 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5 hover:bg-yellow-700">
-        <%= link_to "編集する", edit_post_path(@post), class: "focus:outline-none cursor-pointer" %>
-      </div>
-      <div class= "m-10 text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5 hover:bg-yellow-700">
-        <%= link_to "削除する", post_path(@post), class: "focus:outline-none cursor-pointer", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+  <% if current_user.notown?(@post) %>
+    <div class="ml-15 my-5 flex col-span-2 justify-self-start">
+      <% if @user.image.attached? %>
+        <%= image_tag url_for(@user.image.variant(resize_to_fill: [20, 20])), class: "rounded-full transition duration-200 group-hover:scale-105" %>
+      <% else %>
+        <%= image_tag "プロフィールマーク.png", class:"rounded-full transition duration-300 group-hover:scale-105", width:50 %>
+      <% end %>
+      <div class="my-auto ml-1 font-bold text-yellow-900">
+        <%= link_to @user.name, profile_user_path(@user), class: "text-yellow-900 hover:text-yellow-700" %>
       </div>
     </div>
   <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/flash_messages" %>
-<div class="container mx-auto px-6 py-15 my-15 bg-white rounded-xl min-h-screen max-w-screen-lg text-sm">
+<div class="container mx-auto px-6 py-15 my-15 bg-white shadow-sm shadow-2xs rounded-xl min-h-screen max-w-screen-lg text-sm">
   <div class="grid grid-cols-2 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2 justify-items-center">
     <div class="mb-10">
       <% if @post.image.attached? %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -60,9 +60,6 @@
     </div>
   </div>
 
-  <div class="ml-15 my-5 flex">
-    <%= render "user_profile_button", { user: @user } %>
-  </div>
   <div class="flex items-center justify-center">
     <div class="border-b border-yellow-950 w-[90%]"></div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -24,10 +24,15 @@
           </div>
         <% end %>
       </div>
-      <div class="text-gray-400">
-        <%= l @post.created_at %>
+      <div class="flex mt-1 gap-2">
+        <div class="flex">
+          <%= render "user_profile_button", { user: @user } %>
+        </div>
+        <div class=" text-gray-400">
+          <%= l @post.created_at %>
+        </div>
       </div>
-      <div class= "mt-10 text-yellow-950 max-w-[90%]">
+      <div class= "mt-6 text-yellow-950 max-w-[90%]">
         <%= @post.body %>
       </div>
       <div class="mt-6 flex-col">
@@ -55,20 +60,11 @@
     </div>
   </div>
 
-  <% if current_user.notown?(@post) %>
-    <div class="ml-15 my-5 flex col-span-2 justify-self-start">
-      <% if @user.image.attached? %>
-        <%= image_tag url_for(@user.image.variant(resize_to_fill: [20, 20])), class: "rounded-full transition duration-200 group-hover:scale-105" %>
-      <% else %>
-        <%= image_tag "プロフィールマーク.png", class:"rounded-full transition duration-300 group-hover:scale-105", width:50 %>
-      <% end %>
-      <div class="my-auto ml-1 font-bold text-yellow-900">
-        <%= link_to @user.name, profile_user_path(@user), class: "text-yellow-900 hover:text-yellow-700" %>
-      </div>
-    </div>
-  <% end %>
+  <div class="ml-15 my-5 flex">
+    <%= render "user_profile_button", { user: @user } %>
+  </div>
   <div class="flex items-center justify-center">
-    <div class="border-b border-yellow-950 w-370"></div>
+    <div class="border-b border-yellow-950 w-[90%]"></div>
   </div>
 </div>
 

--- a/app/views/users/_post.html.erb
+++ b/app/views/users/_post.html.erb
@@ -1,0 +1,32 @@
+<% if @posts.present? %>
+  <div class="max-w-275 mx-auto">
+    <div class="grid grid-cols-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5 justify-items-center">
+      <% @posts.each do |post| %>
+        <div class="w-65 h-72 p-4 bg-white shadow-sm shadow-2xs rounded-xl">
+          <div class="group relative block shrink-0 self-start overflow-hidden">
+            <div class="m-2 flex flex-wrap justify-center mx-auto">
+              <%= link_to post_path(post), class: "group" do %>
+                <% if post.image.attached? %>
+                  <%= image_tag url_for(post.image.variant(resize_to_fill: [200, 200])), class: "rounded-xl transition duration-200 group-hover:scale-105" %>
+                <% else %>
+                  <%= image_tag "No_Image.png", class:"rounded-xl transition duration-300 group-hover:scale-105", width:200 %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+          <div class="text-base text-center font-bold text-yellow-900 truncate max-w-[95%]">
+            <%= link_to post.title, post_path(post), class: "hover:text-yellow-600" %>
+          </div>
+          <div class="flex items-end justify-between mt-auto">
+            <div class="flex justify-self-start">
+              <%= render "posts/user_profile_button", { user: post.user } %>
+            </div>
+            <%= render "posts/like_buttons", { post: post } %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% else %>
+  <div class="mb-3 text-center">掲示板がありません</div>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,18 @@
+<div class="container mx-auto px-6 py-15 my-15 bg-white shadow-sm shadow-2xs rounded-xl max-w-screen-sm">
+  <div class="justify-items-center">
+    <%= form_with model: @user do |f| %>
+      <div class="mb-6">
+        <%= f.label :name, class: "block text-yellow-950 font-bold" %>
+        <%= f.text_field :name, class: "w-96 py-2 px-2 bg-stone-50 border border-yellow-950 rounded-md" %>
+      </div>
+      <div class="mt-5">
+        <%= f.label "プロフィール画像", class: "block text-yellow-950 font-bold" %>
+        <%= f.file_field :image, accept: ".jpeg, .gif, .png, .jpg", class: "w-96 py-2 px-2 appearance-none bg-stone-50 border border-yellow-950 rounded w-full text-gray-500 cursor-pointer" %>
+      </div>
+
+      <div class="mt-7 flex justify-center">
+         <%= f.submit "更新する", class: "mt-4 w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,0 +1,3 @@
+<div class="container mx-auto px-6 py-15 my-15 bg-white shadow-sm shadow-2xs rounded-xl min-h-screen max-w-screen-lg text-sm">
+  <%= @user.name %>
+</div>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -11,11 +11,13 @@
         <%= @user.name %>
       </div>
     </div>
-
-    <% if @user == current_user %>
-      <div class="mt-10">
-        <%= link_to "編集する", edit_user_path(current_user), class: "focus:outline-none cursor-pointer text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5 hover:bg-yellow-700" %>
-      </div>
-    <% end %>
   </div>
 </div>
+
+<% if @user == current_user %>
+  <div class="flex justify-center">
+    <%= link_to "編集する", edit_user_path(current_user), class: "mt-4 w-40 rounded-md bg-yellow-900 p-3 text-center text-white focus:outline-none cursor-pointer" %>
+  </div>
+<% else %>
+    <%= render "post" %>
+<% end %>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,3 +1,21 @@
-<div class="container mx-auto px-6 py-15 my-15 bg-white shadow-sm shadow-2xs rounded-xl min-h-screen max-w-screen-lg text-sm">
-  <%= @user.name %>
+<%= render "shared/flash_messages" %>
+<div class="container mx-auto px-6 py-15 my-15 bg-white shadow-sm shadow-2xs rounded-xl max-w-screen-sm">
+  <div class="justify-items-center">
+    <div class="flex">
+      <% if @user.image.attached? %>
+        <%= image_tag url_for(@user.image.variant(resize_to_fill: [50, 50])), class: "rounded-full transition duration-200 group-hover:scale-105" %>
+      <% else %>
+        <%= image_tag "プロフィールマーク.png", class:"rounded-full transition duration-300 group-hover:scale-105", width:50 %>
+      <% end %>
+      <div class="my-auto ml-5 text-base font-bold text-yellow-900">
+        <%= @user.name %>
+      </div>
+    </div>
+
+    <% if @user == current_user %>
+      <div class="mt-10">
+        <%= link_to "編集する", edit_user_path(current_user), class: "focus:outline-none cursor-pointer text-yellow-50 bg-yellow-900 rounded-lg px-5 py-2.5 hover:bg-yellow-700" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
     </div>
 
     <div class= "w-60 h-60 text-center bg-white border border-yellow-900 shadow-2xs rounded-lg p-4 md:p-5">
-      <%= link_to "#" do %>
+      <%= link_to profile_user_path(current_user.id) do %>
         <div class= "p-6 flex flex-wrap justify-center">
           <%= image_tag "プロフィールマーク.png" %>
           <div class="pt-4 text-base text-center font-bold text-yellow-900">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,8 +1,8 @@
 ja:
   activerecord:
     users:
-      name: 'ユーザーネーム'
-      email: 'メールアドレス'
+      name: ユーザーネーム
+      email: メールアドレス
     attributes:
       post:
         title: メニュー名

--- a/config/locales/device.ja.yml
+++ b/config/locales/device.ja.yml
@@ -42,7 +42,8 @@ ja:
       new:
         sign_up: "アカウント登録"
       user:
-        signed_up: "ユーザーを登録し、ログインしました。"
+        signed_up: "ユーザーを登録しログインしました"
+        updated: "プロフィールを更新しました"
     sessions:
       user:
         signed_in: "ログインしました"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -14,5 +14,4 @@ ja:
     sessions:
       new:
         log_in: ログイン
-  post:
     

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     sessions: "users/sessions"
   }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  resources :users, only: [ :show ] do
+  resources :users, only: %i[ show edit update ] do
     member do
       get :my_posts
       get :profile
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
       get :likes
     end
   end
-  resources :likes, only: %i[create destroy]
+  resources :likes, only: %i[ create destroy ]
 
   get  "diagnoses/new", to: "diagnoses#new", as: "new_diagnose"
   post "diagnoses/result", to: "diagnoses#result", as: "diagnoses_result"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,14 +8,17 @@ Rails.application.routes.draw do
   resources :users, only: [ :show ] do
     member do
       get :my_posts
+      get :profile
     end
   end
+
   resources :posts, only: %i[ index new create show edit update destroy ] do
     collection do
       get :likes
     end
   end
   resources :likes, only: %i[create destroy]
+
   get  "diagnoses/new", to: "diagnoses#new", as: "new_diagnose"
   post "diagnoses/result", to: "diagnoses#result", as: "diagnoses_result"
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
プロフィールページを作成。
リンクはマイページと、各ポストに表示。

post_index
・各ポストの投稿日時を表示していたところをユーザー表示に変更
・ユーザー名をリンク表示にし、各ユーザーのプロフィール画面へ遷移可能
post_show
・編集,削除ボタンを移動
・タイトルと日時を上下変更
・ユーザーと日時を横並びで配置。こちらもリンク表示
user_profile
・プロフィール画像登録機能追加
・プロフィール画像とユーザー名を表示
・ログイン中のユーザープロフィール画面の場合はプロフィール編集画面へのリンク表示
・ログイン中以外のユーザープロフィール画面の場合は編集画面表示なし、そのユーザーの投稿ポスト一覧表示


プロフィールへ
リンクはマイページと、各ポストに表示。

post_index
・各ポストの投稿日時を表示していたところをユーザー表示に変更
・ユーザー名をリンク表示にし、各ユーザーのプロフィール画面へ遷移可能
post_show
・編集,削除ボタンを移動
・タイトルと日時を上下変更
・ユーザーと日時を横並びで配置。こちらもリンク表示
user_profile
・プロフィール画像登録機能追加
・プロフィール画像とユーザー名を表示
・ログイン中のユーザープロフィール画面の場合はプロフィール編集画面へのリンク表示
・ログイン中以外のユーザープロフィール画面の場合は編集画面表示なし、そのユーザーの投稿ポスト一覧表示


プロフィールへintroductionカラムを追加し、自己紹介文を登録できるようにするか検討中。