### PR TITLE
add:投稿に関連付けされていないタグを削除

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,8 @@ class Post < ApplicationRecord
 
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
+  before_destroy :remove_unused_tags
+
   has_many :comments, dependent: :destroy
 
   geocoded_by :address
@@ -31,6 +33,17 @@ class Post < ApplicationRecord
   def tag_names=(names)
     self.tags = names.split(",").map do |name|
       Tag.find_or_create_by(name: name.strip)
+    end
+  end
+
+  private
+
+  def remove_unused_tags
+    tags.each do |tag|
+      # 自分のポスト以外にタグが紐づいているか確認
+      if tag.posts.where.not(id: self.id).empty?
+        tag.destroy
+      end
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,7 +6,7 @@ class Post < ApplicationRecord
 
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
-  before_destroy :remove_unused_tags
+  after_destroy :cleanup_unused_tags
 
   has_many :comments, dependent: :destroy
 
@@ -40,10 +40,13 @@ class Post < ApplicationRecord
 
   def remove_unused_tags
     tags.each do |tag|
-      # 自分のポスト以外にタグが紐づいているか確認
       if tag.posts.where.not(id: self.id).empty?
         tag.destroy
       end
     end
+  end
+
+  def cleanup_unused_tags
+    Tag.remove_unused
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,9 +1,8 @@
 class Tag < ApplicationRecord
   has_many :post_tags, dependent: :destroy
+  has_many :posts, through: :post_tags
 
   validates :name, presence: true, uniqueness: true
-
-  scope :popular, -> { where(id: Post_tag.group(:tag_id).order("count_tag_id desc").limit(5).count(:tag_id).keys) }
 
   def self.ransackable_attributes(auth_object = nil)
     [ "name" ]

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -11,4 +11,8 @@ class Tag < ApplicationRecord
   def self.ransackable_associations(auth_object = nil)
     %w[post_tags posts]
   end
+
+  def self.remove_unused
+    left_outer_joins(:posts).where(posts: { id: nil }).destroy_all
+  end
 end


### PR DESCRIPTION
タグ検索に当たって、投稿に関連付けされていないタグが残っていて、検索の妨げになっていた。
このことからpostのdestroyアクションをトリガーとして、関連付けがされていないタグがあった際にタグが削除されるようにした。