### PR TITLE
add:個人情報変更用トークン

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,8 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [ :create ]
   before_action :configure_account_update_params, only: [ :update ]
+  before_action :check_edit_token, only: [ :edit ]
+  after_action :clear_edit_token, only: [ :update ]
 
   # GET /resource/sign_up
   # def new
@@ -63,5 +65,16 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def after_update_path_for(resource)
     profile_user_path(current_user.id)
+  end
+
+  def check_edit_token
+    token = params[:token]
+    return if token.present? && current_user&.edit_profile_token == token
+
+    redirect_to root_path, alert: "不正なアクセスです。"
+  end
+
+  def clear_edit_token
+    @user.update(edit_profile_token: nil)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,7 +35,7 @@ class UsersController < ApplicationController
   def update
     @user = current_user
     if @user.update(user_params)
-      redirect_to profile_user_path, notice: "情報を更新しました。"
+      redirect_to profile_user_path
     else
       render :edit
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,9 @@
 class UserMailer < ApplicationMailer
   def send_change_email(user)
     @user = user
-    @url = edit_user_registration_url(@user, reset_password_token: @token)
+    @token = SecureRandom.urlsafe_base64(32)
+    @user.update!(edit_profile_token: @token)
+    @url = edit_user_registration_url(token: @token)
     mail(to: @user.email, subject: "[SweetsLog]個人情報変更用URLのご案内")
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
+    config.action_mailer.smtp_settings = {
     port: 587,
     domain: "localhost",
     address: "smtp.gmail.com",

--- a/config/locales/device.ja.yml
+++ b/config/locales/device.ja.yml
@@ -43,7 +43,7 @@ ja:
         sign_up: "アカウント登録"
       user:
         signed_up: "ユーザーを登録しログインしました"
-        updated: "プロフィールを更新しました"
+        updated: "更新しました"
     sessions:
       user:
         signed_in: "ログインしました"

--- a/db/migrate/20250710122046_add_column_to_users.rb
+++ b/db/migrate/20250710122046_add_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :edit_profile_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_03_052357) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_10_122046) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -99,6 +99,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_03_052357) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", null: false
+    t.string "edit_profile_token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
・個人情報変更URLにアクセスする際トークンを必須とした。
・現在あるトークンはdeviceにあるreset_password_tokenのみだったため、edit_profile_tokenを追加、削除する処理を追加。
・トークンが無い状態で個人情報変更ページにアクセスすると、不正なアクセスですと出る