### PR TITLE
add:いいね数表示、パスワード表示切替　edit:投稿一覧表示内容変更

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,12 +3,13 @@ import "@hotwired/turbo-rails"
 import "./controllers"
 import jquery from "jquery"
 import "./place_autocomplete.js"
+import "./show_password.js"
 import "./toggle_calendar.js"
 
 window.$ = jquery;
 window.jQuery = $;
 
-$(document).on('turbo:load', function(){
+$(document).on("turbo:load", function(){
   $(".slider").slick({
     variableWidth: true,
     centerMode: true,

--- a/app/javascript/show_password.js
+++ b/app/javascript/show_password.js
@@ -1,0 +1,29 @@
+document.addEventListener("turbo:load", function () {
+  const checkbox = document.getElementById("toggle-password");
+  const passwordField = document.getElementById("password");
+
+  if (checkbox && passwordField) {
+    checkbox.addEventListener("change", function () {
+      if (this.checked) {
+        passwordField.type = "text";
+      } else {
+        passwordField.type = "password";
+      }
+    });
+  }
+});
+
+document.addEventListener("turbo:load", function () {
+  const checkbox = document.getElementById("toggle-password_confirmation");
+  const passwordField = document.getElementById("password_confirmation");
+
+  if (checkbox && passwordField) {
+    checkbox.addEventListener("change", function () {
+      if (this.checked) {
+        passwordField.type = "text";
+      } else {
+        passwordField.type = "password";
+      }
+    });
+  }
+});

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<div class="w-[90%] md:w-150 my-6 container mx-auto px-2 pt-10 pb-6 bg-white shadow-sm shadow-2xs rounded-xl">
+<div class="w-[90%] md:w-150 my-8 container mx-auto px-2 pt-10 pb-6 bg-white shadow-sm shadow-2xs rounded-xl">
   <div class= "mt-4 mb-6 font-bold text-center text-2xl text-yellow-900">
     ユーザー登録
   </div>
@@ -16,12 +16,20 @@
 
       <div class="flex flex-col mt-6">
         <%= f.label :password, class: "text-yellow-950 font-bold" %>
-        <%= f.password_field :password, class: "w-65 md:w-96 p-1.5 bg-stone-50 border border-stone-950 rounded-md", placeholder:"パスワード（6文字以上）" %>
+        <%= f.password_field :password, id: "password", class: "w-65 md:w-96 p-1.5 bg-stone-50 border border-stone-950 rounded-md", placeholder:"パスワード（6文字以上）" %>
+      </div>
+      <div class="mt-1">
+        <input type="checkbox" class="form-check-input" id="toggle-password">
+        <label for="toggle-password">パスワードを表示</label>
       </div>
 
       <div class="flex flex-col mt-6">
         <%= f.label :password_confirmation, class: "text-yellow-950 font-bold" %>
-        <%= f.password_field :password_confirmation, class: "w-65 md:w-96 p-1.5 bg-stone-50 border border-stone-950 rounded-md", placeholder:"もう一度入力してください" %>
+        <%= f.password_field :password_confirmation, id: "password_confirmation", class: "w-65 md:w-96 p-1.5 bg-stone-50 border border-stone-950 rounded-md", placeholder:"もう一度入力してください" %>
+      </div>
+      <div class="mt-1">
+        <input type="checkbox" class="form-check-input" id="toggle-password_confirmation">
+        <label for="toggle-password">パスワードを表示</label>
       </div>
 
       <div class="mt-6 actions flex justify-center">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="w-[90%] md:w-150 my-8 container mx-auto px-2 pt-10 pb-6 bg-white shadow-sm shadow-2xs rounded-xl">
+<div class="w-[90%] md:w-150 my-8 container mx-auto px-2 pt-8 pb-6 bg-white shadow-sm shadow-2xs rounded-xl">
   <div class="my-4 mb-6 font-bold text-center text-2xl text-yellow-900">
     ログイン
   </div>
@@ -17,17 +17,20 @@
 
       <div class="flex flex-col mt-6">
         <%= f.label :password, class: "text-yellow-950 font-bold" %>
-        <%= f.password_field :password, class: "w-65 md:w-96 p-2 bg-stone-50 border border-stone-950 rounded-md", placeholder:"パスワード" %>
+        <%= f.password_field :password, id: "password", class: "w-65 md:w-96 p-2 bg-stone-50 border border-stone-950 rounded-md", placeholder:"パスワード" %>
+      </div>
+      <div class="mt-1">
+        <input type="checkbox" class="form-check-input" id="toggle-password">
+        <label for="toggle-password">パスワードを表示</label>
       </div>
 
-      <% if devise_mapping.rememberable? %>
-        <div class="field mt-6">
-          <%= f.check_box :remember_me %>
-          <%= f.label :remember_me %>
-        </div>
-      <% end %>
-
-      <div class="actions mt-6 flex justify-center">
+      <div class="actions mt-6 flex flex-col items-center justify-center">
+        <% if devise_mapping.rememberable? %>
+          <div class="field my-2">
+            <%= f.check_box :remember_me %>
+            <%= f.label :remember_me %>
+          </div>
+        <% end %>
         <%= f.submit (t "device.sessions.new.log_in"), class: "w-44 rounded-md bg-yellow-900 p-3 text-white focus:outline-none cursor-pointer" %>
       </div>
     <% end %>

--- a/app/views/posts/_edit_and_destroy_buttons.html.erb
+++ b/app/views/posts/_edit_and_destroy_buttons.html.erb
@@ -1,12 +1,22 @@
 <div class="flex gap-1">
-  <%= link_to edit_post_path(post), class: "focus:outline-none cursor-pointer" do %>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5.5 text-yellow-950">
-    <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
-    </svg>
-  <% end %>
-  <%= link_to post_path(post), class: "focus:outline-none cursor-pointer", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5.5 text-yellow-950">
-    <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-    </svg>
-  <% end %>
+  <div class="relative group">
+    <%= link_to edit_post_path(post), class: "focus:outline-none cursor-pointer" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5.5 text-yellow-950">
+      <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+      </svg>
+    <% end %>
+    <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 bg-yellow-950 text-white text-xs rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition whitespace-nowrap">
+      編集する
+    </div>
+  </div>
+  <div class="relative group">
+    <%= link_to post_path(post), class: "focus:outline-none cursor-pointer", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5.5 text-yellow-950">
+      <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+      </svg>
+    <% end %>
+    <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 bg-yellow-950 text-white text-xs rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition whitespace-nowrap">
+      削除する
+    </div>
+  </div>
 </div>

--- a/app/views/posts/_edit_and_destroy_buttons.html.erb
+++ b/app/views/posts/_edit_and_destroy_buttons.html.erb
@@ -1,4 +1,4 @@
-<div class="flex gap-2">
+<div class="flex gap-1">
   <%= link_to edit_post_path(post), class: "focus:outline-none cursor-pointer" do %>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5.5 text-yellow-950">
     <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />

--- a/app/views/posts/_like.html.erb
+++ b/app/views/posts/_like.html.erb
@@ -1,5 +1,6 @@
-<%= link_to likes_path(post_id: post.id), id: "like-button-for-post-#{post.id}", data: { turbo_method: :post } do %>
+<%= link_to likes_path(post_id: post.id), id: "like-button-for-post-#{post.id}", class: "inline-flex gap-1", data: { turbo_method: :post } do %>
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5.5 text-yellow-950">
     <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
   </svg>
+  <%= post.likes.count %>
 <% end %>

--- a/app/views/posts/_like_buttons.html.erb
+++ b/app/views/posts/_like_buttons.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.like?(post) %>
-   <%= render "posts/unlike", { post: post } %>
+  <%= render "posts/unlike", { post: post } %>
 <% else %>
   <%= render "posts/like", { post: post } %>
 <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -19,8 +19,11 @@
     </div>
     <% if local_assigns[:show_actions] != false && current_user %>
       <% if current_user.own?(post) %>
-        <div class="flex gap-1">
-          <%= render "posts/edit_and_destroy_buttons", { post: post } %>
+        <div class="inline-flex gap-1">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5.5 text-yellow-950">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
+          </svg>
+          <%= post.likes.count %>
         </div>
       <% else %>
         <%= render "like_buttons", { post: post } %>

--- a/app/views/posts/_unlike.html.erb
+++ b/app/views/posts/_unlike.html.erb
@@ -1,5 +1,6 @@
-<%= link_to like_path(current_user.likes.find_by(post_id: post.id)), id: "unlike-button-for-post-#{post.id}", data: { turbo_method: :delete } do %>
+<%= link_to like_path(current_user.likes.find_by(post_id: post.id)), id: "unlike-button-for-post-#{post.id}", class: "inline-flex gap-1", data: { turbo_method: :delete } do %>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5.5 text-rose-500">
     <path d="m11.645 20.91-.007-.003-.022-.012a15.247 15.247 0 0 1-.383-.218 25.18 25.18 0 0 1-4.244-3.17C4.688 15.36 2.25 12.174 2.25 8.25 2.25 5.322 4.714 3 7.688 3A5.5 5.5 0 0 1 12 5.052 5.5 5.5 0 0 1 16.313 3c2.973 0 5.437 2.322 5.437 5.25 0 3.925-2.438 7.111-4.739 9.256a25.175 25.175 0 0 1-4.244 3.17 15.247 15.247 0 0 1-.383.219l-.022.012-.007.004-.003.001a.752.752 0 0 1-.704 0l-.003-.001Z" />
   </svg>
+  <%= post.likes.count %>
 <% end %>


### PR DESCRIPTION
フィードバックをいただいたので、その点について修正を行った。
##### 追加内容
・いいね数表示
・投稿編集&削除ボタンへカーソルを合わせた際に「編集する」「削除する」テキストを表示
・ログイン時、ユーザー登録時のパスワード表示切替チェックボックス

##### 修正内容
・投稿一覧でのcurrent_user投稿の場合に表示していた編集&削除ボタンをいいね数表示に変更（自分の投稿のためいいねは出来ない）
（投稿詳細では編集・削除ボタンのまま）

