### PR TITLE
edit:いいねが１つの場合の地図表示ズーム変更

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -8,9 +8,7 @@
         <% if @post.image.persisted? %>
           <%= image_tag(@post.image.variant(resize_to_fill: [360, 360]), class:"rounded-xl") %>
         <% else %>
-          <div class="container w-65 h-65 sm:h-95 sm:w-95 mx-auto flex items-center justify-center rounded-xl bg-gray-300">
-            <p>ここに画像が入ります</p>
-          </div>
+          <a class="container w-65 h-65 sm:h-95 sm:w-95 mx-auto flex items-center justify-center rounded-xl bg-gray-300"></a>
         <% end %>
         <div class="my-5 flex flex-col">
           <%= f.label :image, class: "text-yellow-950 font-bold" %>

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -64,7 +64,12 @@
       });
     });
 
-    map.fitBounds(bounds);
+    if (markers.length === 1) {
+      map.setCenter(markers[0].position);
+      map.setZoom(10);
+    } else {
+      map.fitBounds(bounds);
+    }
   }
 </script>
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_API_KEY"] %>&callback=initMap" async defer></script>


### PR DESCRIPTION
いいねした投稿が１つだった場合に、マーカーを全部収めるfitBoundsだと一番拡大されている状態になってしまい場所が分かりにくいことから、１つの場合と複数の場合とで条件分岐し、１つの場合にズームレベルを指定。